### PR TITLE
compose migration from 3.4 to 3.5

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.4"
+version: "3.5"
 services:
   wireguard:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,10 +24,23 @@ services:
       - "51820:51820/udp"
     sysctls:
       - net.ipv4.conf.all.src_valid_mark=1
+    networks:
+      dncore_network:
+        aliases:
+          - wireguard.wireguard.dappnode
   api:
     build: ./api
     image: "api.wireguard.dnp.dappnode.eth:0.1.0"
     volumes:
       - "wg-config:/config"
+    networks:
+      dncore_network:
+        aliases:
+          - api.wireguard.dappnode
 volumes:
   wg-config: {}
+
+networks:
+  dncore_network:
+    name: dncore_network
+    external: true


### PR DESCRIPTION
- Set `dncore_network` as external (will be asumme as created. The installer should create at installation https://github.com/dappnode/DAppNode_Installer/pull/98)
- Add alias

More info in https://github.com/dappnode/DNP_DAPPMANAGER/issues/655
