### PR TITLE
Changing ymls and jsons

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -7,11 +7,11 @@
   "categories": ["Developer tools"],
   "architectures": ["linux/amd64", "linux/arm64"],
   "links": {
-    "homepage": "https://github.com/Shard-Labs/docker-wireguard"
+    "homepage": "https://github.com/dappnode/DNP_WIREGUARD"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Shard-Labs/docker-wireguard"
+    "url": "https://github.com/dappnode/DNP_WIREGUARD"
   },
   "license": "GLP-3.0"
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,9 +14,9 @@ services:
       - PUID=1000
       - PGID=1000
       - SERVERPORT=51820
-      - PEERDNS=172.33.1.2
+      - PEERDNS=172.33.1.2,10.20.0.2
       - INTERNAL_SUBNET=10.24.0.0
-      - ALLOWEDIPS=172.33.0.0/16
+      - ALLOWEDIPS=172.33.0.0/16,10.20.0.0/24
     volumes:
       - "wg-config:/config"
       - "/lib/modules:/lib/modules"


### PR DESCRIPTION
Change to the .json file is preparation for repo renaming. We need to rename it to have uniform naming across core packages.

Change to the docker-compose file is preparation for DAppNode network change, this shouldn't influence performance except in unlikely cases.  