### PR TITLE
Remove sysctls

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,8 +23,6 @@ services:
       - "/lib/modules:/lib/modules"
     ports:
       - "51820:51820/udp"
-    sysctls:
-      - net.ipv4.conf.all.src_valid_mark=1
     networks:
       dncore_network:
         aliases:


### PR DESCRIPTION
Removing sysctls command because it is used only in client mode.