### PR TITLE
Simplify route

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,36 +1,46 @@
-import express from "express";
+import express, { ErrorRequestHandler } from "express";
 import cors from "cors";
-import { createLocalConfigFile, getRemoteConfigFilePath } from "./createLocalConfigFile";
+import {
+  createLocalConfigFile,
+  getRemoteConfigFilePath,
+} from "./createLocalConfigFile";
 
 const port = process.env.SERVER_PORT || 80;
 
 const app = express();
 app.use(cors());
 
-app.get("/:device/remote/:mode?", (req: express.Request, res: express.Response) => {
+// - remote:    '/dappnode_admin'
+// - remote qr: '/dappnode_admin?qr'
+// - local:     '/dappnode_admin?local'
+// - local qr:  '/dappnode_admin?local&qr'
+app.get("/:device", async (req: express.Request, res: express.Response) => {
   try {
-    const { mode, device } = req.params;
-    const fileExt = mode === "qr" ? "png" : "conf";
-    const remoteFilePath = getRemoteConfigFilePath(device, fileExt);
-    res.status(200).sendFile(remoteFilePath);
+    const { device } = req.params;
+    // Allow to send `?local` without setting to `?local=1`
+    const local = Boolean(req.query.local) || req.query.local === "";
+    const qr = Boolean(req.query.qr) || req.query.qr === "";
+
+    if (local) {
+      if (qr) throw Error("qr mode not supported in local");
+      const localConfigFile = await createLocalConfigFile(device);
+      res.status(200).send(localConfigFile);
+    } else {
+      const fileExt = qr ? "png" : "conf";
+      const remoteFilePath = getRemoteConfigFilePath(device, fileExt);
+      res.status(200).sendFile(remoteFilePath);
+    }
   } catch (e) {
     if (e.code === "ENOENT") res.status(404).send("Not found");
     else res.status(500).send(e.stack);
   }
 });
 
-app.get("/:device/local/:mode?", async (req: express.Request, res: express.Response) => {
-  try {
-    const { mode, device } = req.params;
-    if (mode === "qr") throw Error("qr mode not supported in local");
-
-    const localConfigFile = await createLocalConfigFile(device);
-    res.status(200).send(localConfigFile);
-  } catch (e) {
-    if (e.code === "ENOENT") res.status(404).send("Not found");
-    else res.status(500).send(e.stack);
-  }
-});
+// Return JSON instead of HTML
+const errorJsonHandler: ErrorRequestHandler = async (err, req, res, next) => {
+  res.status(500).send(err);
+};
+app.use(errorJsonHandler);
 
 const server = app.listen(port, () => console.log(`Listening on port ${port}`));
 


### PR DESCRIPTION
- Simplify API route
```
// - remote:    '/dappnode_admin'
// - remote qr: '/dappnode_admin?qr'
// - local:     '/dappnode_admin?local'
// - local qr:  '/dappnode_admin?local&qr'
```

Note setting `local=1`, `local=true`, `local=anything` will work as well

- Return JSON on error