### PR TITLE
Re-order restart property

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,9 @@ services:
           - wireguard.wireguard.dappnode
   api:
     build: ./api
-    restart: unless-stopped
     image: "api.wireguard.dnp.dappnode.eth:0.1.0"
     container_name: DAppNodeCore-api.wireguard.dnp.dappnode.eth
+    restart: unless-stopped
     volumes:
       - "wg-config:/config"
     networks:


### PR DESCRIPTION
`dappnode_install` script modifies the compose file to avoid using the build option when the docker image is loaded on the host.

**After the `build` option must go the `image` option**

More context: https://github.com/dappnode/DAppNodeSDK/issues/172 https://github.com/dappnode/DAppNode_Installer/issues/161