### PR TITLE
fix license typo, fix broken links

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -9,9 +9,12 @@
   "links": {
     "homepage": "https://github.com/dappnode/DNP_WIREGUARD"
   },
+  "bugs": {
+    "url": "https://github.com/dappnode/DNP_WIREGUARD/issues"
+  },
   "repository": {
     "type": "git",
-    "url": "https://github.com/dappnode/DNP_WIREGUARD"
+    "url": "https://github.com/dappnode/DNP_WIREGUARD.git"
   },
-  "license": "GLP-3.0"
+  "license": "GPL-3.0"
 }


### PR DESCRIPTION
fixed the license type typo, and added the report/issues link which is broken in the current version, and fixed the git URL to be the git file with the `.git` extension as used in all other manifests.

