### PR TITLE
Add HOSTNAME global env

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -16,5 +16,11 @@
     "type": "git",
     "url": "https://github.com/dappnode/DNP_WIREGUARD.git"
   },
-  "license": "GPL-3.0"
+  "license": "GPL-3.0",
+  "globalEnvs": [
+    {
+      "envs": ["HOSTNAME"],
+      "services": ["wireguard"]
+    }
+  ]
 }

--- a/root/app/add-peer
+++ b/root/app/add-peer
@@ -17,49 +17,53 @@ fi
 
 if [ -z "$SERVERURL" ] || [ "$SERVERURL" = "auto" ]; then
 
-  function fetchDappnodeDomain {
-    for i in {1..10}; do
+  # If _DAPPNODE_GLOBAL_HOSTNAME is set, use it as SERVERURL
+  if [ ! -z "$_DAPPNODE_GLOBAL_HOSTNAME" ]; then
+    SERVERURL="$_DAPPNODE_GLOBAL_HOSTNAME"
+  else
+    function fetchDappnodeDomain {
+      for i in {1..10}; do
         for domain in "$@"; do
           echo "**** Fetching DAppNode domain from $domain..."
           SERVERURL=$(curl -s "$domain/global-envs/HOSTNAME")
-            if [ ! -z "$SERVERURL" ]; then
-              break
-            fi
+          if [ ! -z "$SERVERURL" ]; then
+            break
+          fi
           sleep 2
         done
-    done
-  }
+      done
+    }
 
-  # TODO: Remove IP when the IP migration is performed
-  domains=("my.dappnode" "dappmanager.dappnode" "172.33.1.7")
+    domains=("my.dappnode" "dappmanager.dappnode" "172.33.1.7" "10.20.0.7")
 
-  fetchDappnodeDomain "${domains[@]}"
+    fetchDappnodeDomain "${domains[@]}"
+  fi
 
 fi
 
 for i in {1..254}; do
-  if grep -q "AllowedIPs = ${INTERFACE}.$(( $i + 1 ))/32" /config/wg0.conf; then
+  if grep -q "AllowedIPs = ${INTERFACE}.$(($i + 1))/32" /config/wg0.conf; then
     echo "Peer $i exists"
   else
     echo "Adding new Peer $i"
     mkdir -p /config/peer${i}
     if [ ! -f /config/peer${i}/privatekey-peer${i} ]; then
       umask 077
-      wg genkey | tee /config/peer${i}/privatekey-peer${i} | wg pubkey > /config/peer${i}/publickey-peer${i}
+      wg genkey | tee /config/peer${i}/privatekey-peer${i} | wg pubkey >/config/peer${i}/publickey-peer${i}
     fi
-    eval "`printf %s`
+    eval "$(printf %s)
     cat <<DUDE > /config/peer${i}/peer${i}.conf
-`cat /config/templates/peer.conf`
+$(cat /config/templates/peer.conf)
 DUDE"
-    cat <<DUDE >> /config/wg0.conf
+    cat <<DUDE >>/config/wg0.conf
 [Peer]
 PublicKey = $(cat /config/peer${i}/publickey-peer${i})
-AllowedIPs = ${INTERFACE}.$(( $i + 1 ))/32
+AllowedIPs = ${INTERFACE}.$(($i + 1))/32
 
 DUDE
     echo "PEER ${i} QR code:"
-    qrencode -t ansiutf8 < /config/peer${i}/peer${i}.conf
-    qrencode -o /config/peer${i}/peer${i}.png < /config/peer${i}/peer${i}.conf
+    qrencode -t ansiutf8 </config/peer${i}/peer${i}.conf
+    qrencode -o /config/peer${i}/peer${i}.png </config/peer${i}/peer${i}.conf
     chown -R abc:abc /config/peer${i}
     s6-svc -t /var/run/s6/services/wireguard
     break

--- a/root/app/add-peer
+++ b/root/app/add-peer
@@ -19,6 +19,7 @@ if [ -z "$SERVERURL" ] || [ "$SERVERURL" = "auto" ]; then
 
   # If _DAPPNODE_GLOBAL_HOSTNAME is set, use it as SERVERURL
   if [ ! -z "$_DAPPNODE_GLOBAL_HOSTNAME" ]; then
+    echo "**** _DAPPNODE_GLOBAL_HOSTNAME is set, using it as SERVERURL ****"
     SERVERURL="$_DAPPNODE_GLOBAL_HOSTNAME"
   else
     function fetchDappnodeDomain {

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -11,13 +11,13 @@ if ip link add dev test type wireguard; then
   ip link del dev test
 else
   echo "**** The wireguard module is not active, will attempt kernel header install and module compilation. If you believe that your kernel should have wireguard support already, make sure that it is activated via modprobe! ****"
-fi  
+fi
 
 # install headers if necessary
 if [ "$SKIP_COMPILE" != "true" ] && [ ! -e /lib/modules/$(uname -r)/build ]; then
   echo "**** Attempting kernel header install ****"
   apt-get update
-  if apt-cache show linux-headers-$(uname -r) 2&>1 >/dev/null; then
+  if apt-cache show linux-headers-$(uname -r) 2 &>1 >/dev/null; then
     apt-get install -y \
       linux-headers-$(uname -r)
   elif (uname -r | grep -q 'v7+') || (uname -r | grep -q 'v7l+') || (uname -r | grep -q 'v8+'); then
@@ -25,7 +25,7 @@ if [ "$SKIP_COMPILE" != "true" ] && [ ! -e /lib/modules/$(uname -r)/build ]; the
     curl -s http://archive.raspberrypi.org/debian/raspberrypi.gpg.key | apt-key add -
     echo -e \
       "deb http://archive.raspberrypi.org/debian/ buster main\ndeb-src http://archive.raspberrypi.org/debian/ buster main" \
-      > /etc/apt/sources.list.d/raspbian.list
+      >/etc/apt/sources.list.d/raspbian.list
     apt-get update
     apt-get install -y \
       raspberrypi-kernel-headers
@@ -35,21 +35,21 @@ if [ "$SKIP_COMPILE" != "true" ] && [ ! -e /lib/modules/$(uname -r)/build ]; the
     if uname -m | grep -q 'x86_64'; then
       echo -e \
         "deb http://archive.ubuntu.com/ubuntu/ bionic main restricted\ndeb-src http://archive.ubuntu.com/ubuntu/ bionic main restricted\n\ndeb http://archive.ubuntu.com/ubuntu/ bionic-updates main restricted\ndeb-src http://archive.ubuntu.com/ubuntu/ bionic-updates main restricted" \
-        > /etc/apt/sources.list.d/xenial-bionic.list
+        >/etc/apt/sources.list.d/xenial-bionic.list
     else
       echo -e \
-      "deb http://ports.ubuntu.com/ubuntu-ports/ bionic main restricted\ndeb-src http://ports.ubuntu.com/ubuntu-ports/ bionic main restricted\n\ndeb http://ports.ubuntu.com/ubuntu-ports/ bionic-updates main restricted\ndeb-src http://ports.ubuntu.com/ubuntu-ports/ bionic-updates main restricted" \
-        > /etc/apt/sources.list.d/xenial-bionic.list
+        "deb http://ports.ubuntu.com/ubuntu-ports/ bionic main restricted\ndeb-src http://ports.ubuntu.com/ubuntu-ports/ bionic main restricted\n\ndeb http://ports.ubuntu.com/ubuntu-ports/ bionic-updates main restricted\ndeb-src http://ports.ubuntu.com/ubuntu-ports/ bionic-updates main restricted" \
+        >/etc/apt/sources.list.d/xenial-bionic.list
     fi
     apt-get update
-    if apt-cache show linux-headers-$(uname -r) 2&>1 >/dev/null; then
+    if apt-cache show linux-headers-$(uname -r) 2 &>1 >/dev/null; then
       apt-get install -y \
         linux-headers-$(uname -r)
     else
       echo "**** No kernel headers found in the Ubuntu Bionic repo!! Trying Ubuntu Xenial. ****"
       sed -i 's/bionic/xenial/g' /etc/apt/sources.list.d/xenial-bionic.list
       apt-get update
-      if apt-cache show linux-headers-$(uname -r) 2&>1 >/dev/null; then
+      if apt-cache show linux-headers-$(uname -r) 2 &>1 >/dev/null; then
         apt-get install -y \
           linux-headers-$(uname -r)
       else
@@ -61,7 +61,7 @@ if [ "$SKIP_COMPILE" != "true" ] && [ ! -e /lib/modules/$(uname -r)/build ]; the
     echo "**** Debian host detected, attempting to install kernel headers from Debian Buster repo ****"
     curl -s https://ftp-master.debian.org/keys/archive-key-10.asc | apt-key add -
     curl -s https://ftp-master.debian.org/keys/archive-key-10-security.asc | apt-key add -
-    cat <<DUDE > /etc/apt/sources.list.d/debian.list
+    cat <<DUDE >/etc/apt/sources.list.d/debian.list
 deb http://deb.debian.org/debian buster main contrib non-free
 deb-src http://deb.debian.org/debian buster main contrib non-free
 deb http://deb.debian.org/debian-security/ buster/updates main contrib non-free
@@ -72,7 +72,7 @@ deb http://deb.debian.org/debian buster-backports main contrib non-free
 deb-src http://deb.debian.org/debian buster-backports main contrib non-free
 DUDE
     apt-get update
-    if apt-cache show linux-headers-$(uname -r) 2&>1 >/dev/null; then
+    if apt-cache show linux-headers-$(uname -r) 2 &>1 >/dev/null; then
       if uname -r | grep -qs "bpo"; then
         echo "**** Backported kernel detected ****"
         apt-get install -y -t buster-backports \
@@ -87,7 +87,7 @@ DUDE
       curl -s https://ftp-master.debian.org/keys/archive-key-9-security.asc | apt-key add -
       sed -i 's/buster/stretch/g' /etc/apt/sources.list.d/debian.list
       apt-get update
-      if apt-cache show linux-headers-$(uname -r) 2&>1 >/dev/null; then
+      if apt-cache show linux-headers-$(uname -r) 2 &>1 >/dev/null; then
         if uname -r | grep -qs "bpo"; then
           echo "**** Backported kernel detected ****"
           apt-get install -y -t stretch-backports \
@@ -107,12 +107,12 @@ DUDE
 fi
 
 if [ "$SKIP_COMPILE" != "true" ]; then
-  if [ -e /lib/modules/$(uname -r)/build ]; then 
+  if [ -e /lib/modules/$(uname -r)/build ]; then
     echo "**** Kernel headers seem to be present, attempting to build the wireguard module. . . ****"
     if [ ! -f /lib/modules/$(uname -r)/build/certs/signing_key.pem ]; then
       mkdir -p /lib/modules/$(uname -r)/build/certs
       cd /lib/modules/$(uname -r)/build/certs
-      cat <<DUDE >> x509.genkey
+      cat <<DUDE >>x509.genkey
 [ req ]
 default_bits = 4096
 distinguished_name = req_distinguished_name
@@ -133,18 +133,18 @@ DUDE
       openssl req -new -nodes -utf8 -sha512 -days 36500 -batch -x509 -config x509.genkey -outform DER -out signing_key.x509 -keyout signing_key.pem
     fi
     cd /app
-    for release in "" "v1.0.20200520" "v1.0.20200330" "v0.0.20200105"; do 
+    for release in "" "v1.0.20200520" "v1.0.20200330" "v0.0.20200105"; do
       echo "**** Building the module ****"
-      if ! [ -z ${release} ] ;  then
-            echo "Wireguard release ${release} set, checking out correct version"
-            cd wireguard-linux-compat
-            git checkout $release
-            cd .. 
+      if ! [ -z ${release} ]; then
+        echo "Wireguard release ${release} set, checking out correct version"
+        cd wireguard-linux-compat
+        git checkout $release
+        cd ..
       fi
       make -C wireguard-linux-compat/src -j$(nproc) && returncode=$? || returncode=$?
       if [ $returncode -ne 0 ]; then continue; fi
-      make -C wireguard-linux-compat/src install  && returncode=$? || returncode=$?
-      if [ $returncode -eq 0 ] ; then  break; fi
+      make -C wireguard-linux-compat/src install && returncode=$? || returncode=$?
+      if [ $returncode -eq 0 ]; then break; fi
     done
     echo "**** Let's test our new module. ****"
     ip link del dev test 2>/dev/null
@@ -166,20 +166,20 @@ rm -rf /etc/wireguard
 mkdir -p /etc/wireguard
 ln -s /config/wg0.conf /etc/wireguard/wg0.conf
 # prepare templates
-[[ ! -f /config/templates/server.conf ]] && \
+[[ ! -f /config/templates/server.conf ]] &&
   cp /defaults/server.conf /config/templates/server.conf
-[[ ! -f /config/templates/peer.conf ]] && \
+[[ ! -f /config/templates/peer.conf ]] &&
   cp /defaults/peer.conf /config/templates/peer.conf
 
-generate_confs () {
+generate_confs() {
   mkdir -p /config/server
   if [ ! -f /config/server/privatekey-server ]; then
     umask 077
-    wg genkey | tee /config/server/privatekey-server | wg pubkey > /config/server/publickey-server
+    wg genkey | tee /config/server/privatekey-server | wg pubkey >/config/server/publickey-server
   fi
-  eval "`printf %s`
+  eval "$(printf %s)
   cat <<DUDE > /config/wg0.conf
-`cat /config/templates/server.conf`
+$(cat /config/templates/server.conf)
 
 DUDE"
   for i in ${PEERS_ARRAY[@]}; do
@@ -191,7 +191,7 @@ DUDE"
     mkdir -p /config/${PEER_ID}
     if [ ! -f "/config/${PEER_ID}/privatekey-${PEER_ID}" ]; then
       umask 077
-      wg genkey | tee /config/${PEER_ID}/privatekey-${PEER_ID} | wg pubkey > /config/${PEER_ID}/publickey-${PEER_ID}
+      wg genkey | tee /config/${PEER_ID}/privatekey-${PEER_ID} | wg pubkey >/config/${PEER_ID}/publickey-${PEER_ID}
     fi
     if [ -f "/config/${PEER_ID}/${PEER_ID}.conf" ]; then
       CLIENT_IP=$(cat /config/${PEER_ID}/${PEER_ID}.conf | grep "Address" | awk '{print $NF}')
@@ -207,11 +207,11 @@ DUDE"
         fi
       done
     fi
-    eval "`printf %s`
+    eval "$(printf %s)
     cat <<DUDE > /config/${PEER_ID}/${PEER_ID}.conf
-`cat /config/templates/peer.conf`
+$(cat /config/templates/peer.conf)
 DUDE"
-    cat <<DUDE >> /config/wg0.conf
+    cat <<DUDE >>/config/wg0.conf
 [Peer]
 # ${PEER_ID}
 PublicKey = $(cat /config/${PEER_ID}/publickey-${PEER_ID})
@@ -219,13 +219,13 @@ AllowedIPs = ${CLIENT_IP}/32
 
 DUDE
     echo "PEER ${i} QR code:"
-    qrencode -t ansiutf8 < /config/${PEER_ID}/${PEER_ID}.conf
-    qrencode -o /config/${PEER_ID}/${PEER_ID}.png < /config/${PEER_ID}/${PEER_ID}.conf
+    qrencode -t ansiutf8 </config/${PEER_ID}/${PEER_ID}.conf
+    qrencode -o /config/${PEER_ID}/${PEER_ID}.png </config/${PEER_ID}/${PEER_ID}.conf
   done
 }
 
-save_vars () {
-  cat <<DUDE > /config/.donoteditthisfile
+save_vars() {
+  cat <<DUDE >/config/.donoteditthisfile
 ORIG_SERVERURL="$SERVERURL"
 ORIG_SERVERPORT="$SERVERPORT"
 ORIG_PEERDNS="$PEERDNS"
@@ -245,28 +245,33 @@ if [ -n "$PEERS" ]; then
   PEERS_COUNT=$(echo "${#PEERS_ARRAY[@]}")
   if [ -z "$SERVERURL" ] || [ "$SERVERURL" = "auto" ]; then
 
-    function fetchDappnodeDomain {
-      for i in {1..30}; do
+    # If _DAPPNODE_GLOBAL_HOSTNAME is set, use it as SERVERURL
+    if [ ! -z "$_DAPPNODE_GLOBAL_HOSTNAME" ]; then
+      SERVERURL="$_DAPPNODE_GLOBAL_HOSTNAME"
+    else
+
+      function fetchDappnodeDomain {
+        for i in {1..30}; do
           for domain in "$@"; do
-              echo "**** Fetching DAppNode domain from $domain..."
-              SERVERURL=$(curl -s "$domain/global-envs/HOSTNAME")
-              if [ ! -z "$SERVERURL" ]; then
-                  break 2
-              fi
-              sleep 2
+            echo "**** Fetching DAppNode domain from $domain..."
+            SERVERURL=$(curl -s "$domain/global-envs/HOSTNAME")
+            if [ ! -z "$SERVERURL" ]; then
+              break 2
+            fi
+            sleep 2
           done
-      done
-    }
+        done
+      }
 
-    # TODO: Remove IP when the IP migration is performed
-    domains=("my.dappnode" "dappmanager.dappnode" "172.33.1.7")
+      domains=("my.dappnode" "dappmanager.dappnode" "172.33.1.7" "10.20.0.7")
 
-    fetchDappnodeDomain "${domains[@]}"
+      fetchDappnodeDomain "${domains[@]}"
+    fi
 
     if [ -z "$SERVERURL" ]; then
-        echo "**** SERVERURL var is either not set or is set to \"auto\", setting external IP to auto detected value of $SERVERURL  ****"
+      echo "**** SERVERURL var is either not set or is set to \"auto\", setting external IP to auto detected value of $SERVERURL  ****"
     else
-        echo "**** SERVERURL var is set to $SERVERURL ****"
+      echo "**** SERVERURL var is set to $SERVERURL ****"
     fi
   else
     echo "**** External server address is set to $SERVERURL ****"
@@ -291,7 +296,7 @@ if [ -n "$PEERS" ]; then
     save_vars
   else
     echo "**** Server mode is selected ****"
-    [[ -f /config/.donoteditthisfile ]] && \
+    [[ -f /config/.donoteditthisfile ]] &&
       . /config/.donoteditthisfile
     if [ "$SERVERURL" != "$ORIG_SERVERURL" ] || [ "$SERVERPORT" != "$ORIG_SERVERPORT" ] || [ "$PEERDNS" != "$ORIG_PEERDNS" ] || [ "$PEERS" != "$ORIG_PEERS" ] || [ "$INTERFACE" != "$ORIG_INTERFACE" ] || [ "$ALLOWEDIPS" != "$ORIG_ALLOWEDIPS" ]; then
       echo "**** Server related environment variables changed, regenerating 1 server and ${PEERS} peer/client confs ****"
@@ -312,9 +317,9 @@ else
 fi
 
 # set up CoreDNS
-[[ ! -f /config/coredns/Corefile ]] && \
+[[ ! -f /config/coredns/Corefile ]] &&
   cp /defaults/Corefile /config/coredns/Corefile
 
 # permissions
 chown -R abc:abc \
-	/config
+  /config

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -247,6 +247,7 @@ if [ -n "$PEERS" ]; then
 
     # If _DAPPNODE_GLOBAL_HOSTNAME is set, use it as SERVERURL
     if [ ! -z "$_DAPPNODE_GLOBAL_HOSTNAME" ]; then
+      echo "**** _DAPPNODE_GLOBAL_HOSTNAME is set, using it as SERVERURL ****"
       SERVERURL="$_DAPPNODE_GLOBAL_HOSTNAME"
     else
 


### PR DESCRIPTION
In order to improve package resilience and guarantee VPN access, here we add `HOSTNAME` as a global env so that we do not need to fetch it from the Dappmanager API. Also, in the case this domain changes, the wireguard package will be restarted with the new value